### PR TITLE
shifted: code to get auth data from context function to auth directive

### DIFF
--- a/src/functions/graphql/context.ts
+++ b/src/functions/graphql/context.ts
@@ -1,43 +1,26 @@
 import { Account, Company, PrismaClient, User } from "@prisma/client";
 import { algolia, Algolia } from "@utils/algolia";
 import { store } from "@utils/store";
-import { decodeToken } from "@utils/token-helper";
 import { DataSources } from "./dataSources";
-import { GqlError } from "./error";
 
 export type Context = {
+    event: any;
     store: PrismaClient;
     algolia: Algolia;
     sourceIp: string;
     userAgent: string;
     dataSources?: DataSources;
-    authData: Pick<Account, "email" | "phoneNumber" | "roles" | "profileType"> & Partial<User & Company>;
-};
-
-const getAuthData = (event) => {
-    try {
-        const token = event.headers.Authorization || event.headers.authorization;
-        return decodeToken(token, "access") || { roles: ["unknown"] };
-    } catch (error) {
-        const code = "FORBIDDEN";
-        const message = error.name === "TokenExpiredError" ? "Token expired" : "Invalid token";
-        const action = error.name === "TokenExpiredError" ? "refresh-token" : "logout";
-
-        console.log({ code, message, action });
-        throw new GqlError({ code, message, action });
-    }
+    authData?: Pick<Account, "email" | "phoneNumber" | "roles" | "profileType"> & Partial<User & Company>;
 };
 
 export default ({ event }): Context => {
     const { sourceIp, userAgent } = event.requestContext.identity;
 
-    const authData = getAuthData(event);
-
     return {
+        event,
         store,
         algolia,
         sourceIp,
         userAgent,
-        authData,
     };
 };

--- a/src/functions/graphql/schema/account/login.ts
+++ b/src/functions/graphql/schema/account/login.ts
@@ -79,7 +79,7 @@ const login: Login = async (_, { input }, { store, sourceIp, userAgent }, info) 
     const accessToken = encodeToken({ accountId: account.id, ...profile }, "access", { jwtid: account.id });
     const refreshToken = encodeToken({ accountId: account.id }, "refresh", { jwtid: session.id });
 
-    return { profile, accessToken, refreshToken, roles: account.roles };
+    return { profile, accessToken, refreshToken };
 };
 
 export const loginTypeDefs = gql`
@@ -90,7 +90,6 @@ export const loginTypeDefs = gql`
 
     type LoginResult {
         profile: Profile!
-        roles: [String]!
         accessToken: String!
         refreshToken: String!
     }

--- a/src/functions/graphql/schema/core/authDirective.ts
+++ b/src/functions/graphql/schema/core/authDirective.ts
@@ -4,6 +4,32 @@ import { defaultFieldResolver } from "graphql";
 import { authStrategies } from "@libs/authorizer";
 import { Log } from "@utils/logger";
 import { GqlError } from "../../error";
+import { decodeToken } from "@utils/token-helper";
+
+const getAuthData = async (event) => {
+    try {
+        const token = event.headers.Authorization || event.headers.authorization;
+        return decodeToken(token, "access") || { roles: ["unknown"] };
+    } catch (error) {
+        const code = "FORBIDDEN";
+        const message = error.name === "TokenExpiredError" ? "Token expired" : "Invalid token";
+        const action = error.name === "TokenExpiredError" ? "refresh-token" : "logout";
+
+        console.log({ code, message, action });
+        throw new GqlError({ code, message, action });
+    }
+};
+
+const executeStrategy = async (requiredRoles, requestData) => {
+    Log("Required roles", requiredRoles, "Current role", requestData.roles);
+
+    for (let role of requiredRoles) {
+        const strategyResult = await authStrategies[role.toLowerCase()](requestData);
+        if (strategyResult) return;
+    }
+
+    throw new GqlError({ code: "UNAUTHORIZED", message: "Not authorized" });
+};
 
 class AuthDirective extends SchemaDirectiveVisitor {
     visitObject(object) {
@@ -26,37 +52,25 @@ class AuthDirective extends SchemaDirectiveVisitor {
         Object.keys(fields).forEach((fieldName) => {
             const field = fields[fieldName];
             const { resolve = defaultFieldResolver } = field;
-            const executeStrategy = this.executeStrategy;
             field.resolve = async function (...args) {
                 // Get the required Role from the field first, falling back
                 // to the objectType if no Role is required by the field
                 const requiredRoles = field._requiredAuthRole || objectType._requiredAuthRole;
 
                 if (!requiredRoles) return resolve.apply(this, args);
-                Log({ fieldName, requiredRole: requiredRoles });
+                Log({ fieldName });
 
-                // Get the principal object of type AuthenticatedUser from
-                // which we can get user's role to check whether the user
-                // has the role required to access this field
-                const authData = args[2]?.authData;
+                const authData = await getAuthData(args[2]?.event);
                 if (authData?.roles?.length === 0)
                     throw new GqlError({ code: "UNAUTHORIZED", message: "Not authorized" });
 
                 await executeStrategy(requiredRoles, authData);
-                return await resolve.apply(this, args);
+
+                // Assign the value of authData in the context
+                const argsWithAuthData = args.map((arg, index) => (index === 2 ? { ...arg, authData } : arg));
+                return await resolve.apply(this, argsWithAuthData);
             };
         });
-    }
-
-    private async executeStrategy(requiredRoles, requestData) {
-        Log("Required", requiredRoles, "Current role", requestData.roles);
-
-        for (let role of requiredRoles) {
-            const strategyResult = await authStrategies[role.toLowerCase()](requestData);
-            if (strategyResult) return;
-        }
-
-        throw new GqlError({ code: "UNAUTHORIZED", message: "Not authorized" });
     }
 }
 

--- a/src/utils/algolia/indices/spaceIndex.ts
+++ b/src/utils/algolia/indices/spaceIndex.ts
@@ -36,4 +36,4 @@ const settings: Settings = {
     searchableAttributes: ["name", "spaceTypes"],
 };
 
-spaceIndex.setSettings(settings).catch((error) => Log("[FAILED]: setting space index", error));
+// spaceIndex.setSettings(settings).catch((error) => Log("[FAILED]: setting space index", error));


### PR DESCRIPTION
Previously, authorization token is decoded in every gql call, as it is done in the apollo server context function, resulting in token expired error when expired token is passed even while calling queries or mutation which doesn't require any authorization as mentioned in #75 .

So I have moved the function to decode authorization token in auth directive. Now token is decoded only while calling queries or mutation where the auth directive is applied. This makes us able to call the queries or mutation which doesn't requires authorization even when an expired token is passed.

I think this resolves #75 issue. 

Additionally, I have commented code to set the settings in algolia space index as it was running in every api call resulting in multiple algolia calls.